### PR TITLE
Fix some platform names

### DIFF
--- a/_alternatives/Platforms/gb.json
+++ b/_alternatives/Platforms/gb.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy",
+    "name": "Game Boy",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1989

--- a/_alternatives/Platforms/gba.json
+++ b/_alternatives/Platforms/gba.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy Advance",
+    "name": "Game Boy Advance",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 2001

--- a/_alternatives/Platforms/gbc.json
+++ b/_alternatives/Platforms/gbc.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy Color",
+    "name": "Game Boy Color",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1998

--- a/_alternatives/Platforms/gg.json
+++ b/_alternatives/Platforms/gg.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Sega GameGear",
+    "name": "Sega Game Gear",
     "category": "Handheld",
     "manufacturer": "Sega",
     "year": 1990

--- a/_alternatives/Platforms/nes.json
+++ b/_alternatives/Platforms/nes.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Nintendo NES",
+    "name": "NES",
     "category": "Console",
     "manufacturer": "Nintendo",
     "year": 1985

--- a/_alternatives/Platforms/sgb.json
+++ b/_alternatives/Platforms/sgb.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Super GameBoy",
+    "name": "Super Game Boy",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1994

--- a/_alternatives/Platforms/sms.json
+++ b/_alternatives/Platforms/sms.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "MasterSystem",
+    "name": "Master System",
     "category": "Console",
     "manufacturer": "Sega",
     "year": 1985

--- a/home/Platforms/gb.json
+++ b/home/Platforms/gb.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy",
+    "name": "Game Boy",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1989

--- a/home/Platforms/gba.json
+++ b/home/Platforms/gba.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy Advance",
+    "name": "Game Boy Advance",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 2001

--- a/home/Platforms/gbc.json
+++ b/home/Platforms/gbc.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "GameBoy Color",
+    "name": "Game Boy Color",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1998

--- a/home/Platforms/gg.json
+++ b/home/Platforms/gg.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Sega GameGear",
+    "name": "Sega Game Gear",
     "category": "Handheld",
     "manufacturer": "Sega",
     "year": 1990

--- a/home/Platforms/nes.json
+++ b/home/Platforms/nes.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Nintendo NES",
+    "name": "NES",
     "category": "Console",
     "manufacturer": "Nintendo",
     "year": 1985

--- a/home/Platforms/sgb.json
+++ b/home/Platforms/sgb.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Super GameBoy",
+    "name": "Super Game Boy",
     "category": "Handheld",
     "manufacturer": "Nintendo",
     "year": 1994

--- a/home/Platforms/sms.json
+++ b/home/Platforms/sms.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "MasterSystem",
+    "name": "Master System",
     "category": "Console",
     "manufacturer": "Sega",
     "year": 1986


### PR DESCRIPTION
This commit just changes a few platform names to be more in line with what is commonly accepted as canonical spelling/spacing:

* "GameBoy" changed to "Game Boy"
* "GameGear" changed to "Game Gear"
* "MasterSystem" changed to "Master System"
* "Nintendo NES" changed to "NES" (Nintendo is redundant there)