### PR TITLE
improved platform names

### DIFF
--- a/arcade/Platforms/jtaliens.json
+++ b/arcade/Platforms/jtaliens.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Konami (Aliens)",
+    "name": "Aliens",
     "category": "Arcade Multi",
     "manufacturer": "Konami",
     "year": 1990

--- a/arcade/Platforms/jtkiwi.json
+++ b/arcade/Platforms/jtkiwi.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Taito (NewZealand)",
+    "name": "The NewZealand Story",
     "category": "Arcade Multi",
     "manufacturer": "Taito",
     "year": 1989

--- a/arcade/Platforms/jtsimson.json
+++ b/arcade/Platforms/jtsimson.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Konami Simpsons",
+    "name": "The Simpsons",
     "category": "Arcade Multi",
     "manufacturer": "Konami",
     "year": 1991

--- a/arcade/Platforms/jttmnt.json
+++ b/arcade/Platforms/jttmnt.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "name": "Konami TMNT",
+    "name": "Teenage Mutant Ninja Turtles",
     "category": "Arcade Multi",
     "manufacturer": "Konami",
     "year": 1989


### PR DESCRIPTION
Hey there,

first off, thanks a lot for providing this repository! :bow: 

The `arcace/Platform/jt*.json` files are being used by [Matt Pannella](https://github.com/mattpannella)'s [Analogue Pocket Updater Utility](https://github.com/mattpannella/pocket-updater-utility); providing better names for all `jt`-cores.

I'm currently trying to implement this feature for my own [Ansible Analogue Pocket](https://github.com/4ch1m/ansible-analogue-pocket) project as well.

However, some of the names are not quite "correct".

e.g.

```
Konami (Aliens)
Konami Simpsons
Konami TMNT
```

These games will be sorted in alongside all other arcades/games starting with `K`.
Which isn't ideal when navigating/browsing the Pocket's menu.

This PR will fix this.

Again... thank you very much!