### PR TITLE
Update jtgaiden.json

### DIFF
--- a/arcade/Platforms/jtgaiden.json
+++ b/arcade/Platforms/jtgaiden.json
@@ -3,6 +3,6 @@
     "category": "Arcade",
     "manufacturer": "Tecmo",
     "year": 1988,
-    "name": "★Ninja Gaiden"
+    "name": "Ninja Gaiden"
   }
 }


### PR DESCRIPTION
Remove the ★ from the `name` field for `Ninja Gaiden` otherwise the game is all the way down the bottom of the game list